### PR TITLE
fix: Ensure local modules can be imported, by adding path setup

### DIFF
--- a/src/agent/dummy_agent.py
+++ b/src/agent/dummy_agent.py
@@ -2,7 +2,14 @@
 This file defines a barebones agent.
 """
 import asyncio
+import os
+import sys
 from langchain.agents import create_agent
+
+
+# NECESSARY: In order to enable imports from local modules
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+# pylint: disable=wrong-import-position
 from src.agent.tools.github import git_clone_tool
 from src.mcp.mcp_client_factory import create_mcp_client_from_config
 


### PR DESCRIPTION
This pull request updates the import logic in `src/agent/dummy_agent.py` to ensure that local modules can be imported correctly. The most important change is the addition of code to modify the Python path so that imports from local modules work as expected.

Import path configuration:

* Added logic to prepend the parent directory of the repository root to `sys.path`, enabling local module imports in `dummy_agent.py`.